### PR TITLE
dotenv

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "author": "Laminar Developers",
   "private": true,
   "dependencies": {
+    "dotenv": "^8.2.0",
     "express": "^4.17.1",
     "flow-protocol": "laminar-protocol/flow-protocol-ethereum",
     "node-fetch": "^2.6.0",

--- a/src/envVars.ts
+++ b/src/envVars.ts
@@ -1,20 +1,41 @@
-const VARS = {
-  CONSOLE_LOG: 'CONSOLE_LOG', // 'true' or 'false'
+import { config as dotenvConfig } from "dotenv";
 
+const REQUIRED_VARS = {
   ALPHA_VANTAGE_API_KEY: 'ALPHA_VANTAGE_API_KEY',
+  PRICE_FEED_INTERVAL_MS: 'PRICE_FEED_INTERVAL_MS', // by milliseconds
 
   WEB3_PROVIDER: 'WEB3_PROVIDER',
   ETH_PRIVATE_KEY: 'ETH_PRIVATE_KEY',
-
   CHAIN: 'CHAIN',
   GAS_LIMIT: 'GAS_LIMIT',
+};
 
-  PRICE_FEED_INTERVAL_MS: 'PRICE_FEED_INTERVAL_MS', // by milliseconds
+const LOCAL_TESTNET_VARS = {
+  CONSOLE_LOG: 'CONSOLE_LOG', // 'true' or 'false'
 
-  // local test
   LOCAL_TESTNET_ORACLE_CONTRACT_ADDR: 'LOCAL_TESTNET_ORACLE_CONTRACT_ADDR',
   FJPY: 'LOCAL_TESTNET_FJPY_ADDR',
   FEUR: 'LOCAL_TESTNET_FEUR_ADDR',
 };
+
+const VARS = { ...REQUIRED_VARS, ...LOCAL_TESTNET_VARS };
+
+const configVars = () => {
+  // init dotenv
+  const result = dotenvConfig();
+  if (result.error) {
+    throw result.error;
+  }
+
+  // check required vars
+  Object.values(REQUIRED_VARS).forEach((varKey: string) => {
+    const variable = process.env[varKey];
+    if (variable === undefined) {
+      throw new Error(`no ${varKey} environment variable`)
+    }
+  });
+};
+
+configVars();
 
 export default VARS;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1650,6 +1650,11 @@ domexception@^1.0.1:
   dependencies:
     webidl-conversions "^4.0.2"
 
+dotenv@^8.2.0:
+  version "8.2.0"
+  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-8.2.0.tgz#97e619259ada750eea3e4ea3e26bceea5424b16a"
+  integrity sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw==
+
 drbg.js@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/drbg.js/-/drbg.js-1.0.1.tgz#3e36b6c42b37043823cdbc332d58f31e2445480b"


### PR DESCRIPTION
Better to have dotenv feature at first to make deployment easier. Additionally add required vars check to prevent unintended behaviors.

This closes #4.